### PR TITLE
Update nextjs.mdx

### DIFF
--- a/reference/backend-apis/nextjs.mdx
+++ b/reference/backend-apis/nextjs.mdx
@@ -23,9 +23,9 @@ To initialize the PropelAuth library in `lib/propelauth.js`, enter the code
 below, making sure to include the ***newline characters*** in your **verifierKey**:
 
 ```js
-import { initAuth } from "@propelauth/express";
+import { initBaseAuth } from "@propelauth/node";
 
-const propelauth = initAuth({
+const propelauth = initBaseAuth({
   // If true, error messages returned to the user will be detailed.
   // It's useful for debugging, but a good idea to turn off in production.
   debugMode: true,


### PR DESCRIPTION
Ran into this issue with the docs when implementing this in our Next.js app. The docs say to import `initAuth` from `@propelauth/express` and then to reference `validateAccessTokenAndGetUser` from the resulting object, but `validateAccessTokenAndGetUser` does not exist on that object. I eventually figured out that this was a typo, and that I was meant to use `initBaseAuth` from `@propelauth/node`