### PR TITLE
docs: Typo in Github Social Login

### DIFF
--- a/reference/social-login/github.mdx
+++ b/reference/social-login/github.mdx
@@ -11,7 +11,7 @@ The official Github guide is
 [here](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app).
 
 <Note>
-  Users that sign up via Google look the same as users that sign up via any
+  Users that sign up via Github look the same as users that sign up via any
   other method. Your code will handle both automatically.
 </Note>
 


### PR DESCRIPTION
I imagine this was copy-pasted from the Google page. I believe the note should reference Github, not Google. 