### PR TITLE
Update frontend docs linking

### DIFF
--- a/reference/frontend-apis/js.mdx
+++ b/reference/frontend-apis/js.mdx
@@ -158,7 +158,7 @@ authClient.getAuthenticationInfoOrNull(forceRefresh?: boolean): Promise<Authenti
 If the user is logged in, this method returns authentication information about
 them, including their access token, user metadata, and, for B2B applications,
 organization information. See
-[AuthenticationInfo schema](#authentication-info-and-user-metadata)
+[AuthenticationInfo schema](#authenticationinfo-and-user-metadata)
 for the full schema. Otherwise, this method returns null.
 
 The promise will generally resolve immediately, without making an external


### PR DESCRIPTION
The linking has a typo, this should properly link to the right doc section. The right link should be directed to here:
https://docs.propelauth.com/reference/frontend-apis/js#authenticationinfo-and-user-metadata

I am one of the new folks that got the "free until I raise money" and so I want to help if I can.